### PR TITLE
Fixing the bug that lead to biased inference with the new speed-up

### DIFF
--- a/main.py
+++ b/main.py
@@ -252,7 +252,12 @@ def _get_likelihood(
             )
             del fi_bu_en_czl_i, fi_bu_en_czu_i, fi_bu_en_rl_i, fi_bu_en_ru_i
 
+            tau_sh = np.shape(tau_now_i)
+            tau_now_i_fl = tau_now_i.flatten()
+            tau_now_i_fl[tau_now_i_fl < 0.0] = np.inf
+            tau_now_i = tau_now_i_fl.reshape(tau_sh)
             tau_now_i = np.nan_to_num(tau_now_i, np.inf)
+
             tau_now_full[n * n_inside_tau:(n + 1) * n_inside_tau, :] = tau_now_i
             eit_l = np.exp(-np.array(tau_now_i))
 

--- a/main.py
+++ b/main.py
@@ -386,7 +386,7 @@ def _get_likelihood(
                 dict_dat_aft
             )
 
-            names_used.append(save_cl.f_name)
+            names_used_this_iter = [].append(save_cl.f_name)
             save_cl.close()
             del save_cl, dict_dat_aft
         flux_tot.append(np.array(flux_now).flatten())

--- a/main.py
+++ b/main.py
@@ -474,6 +474,9 @@ def _get_likelihood(
                         data_to_get = np.log10(
                             1e18 * (5e-19 + spec_line[:, bin_i - 1, 1:4]).T
                         )
+                    print(data_to_get, flush=True)
+                    print("just in case, print", data_to_get[0], flush=True)
+                    print("also", data_to_get[-1], flush=True)
                     # print(spec_line[:,bin_i-1, 1:bin_i], np.shape(spec_line[:,bin_i-1, 1:bin_i]))
                     spec_kde = gaussian_kde(data_to_get, bw_method=0.2)
 

--- a/main.py
+++ b/main.py
@@ -860,7 +860,7 @@ if __name__ == '__main__':
     parser.add_argument("--noise_on_the_spectrum", type=float, default=2e-20)
     parser.add_argument("--consistent_noise", action="store_true")
     parser.add_argument("--constrained_prior", action="store_true")
-    parser.add_argumnet("--AH22_model", action="store_true")
+    parser.add_argument("--AH22_model", action="store_true")
     inputs = parser.parse_args()
 
     if inputs.uvlf_consistently:

--- a/main.py
+++ b/main.py
@@ -305,8 +305,8 @@ def _get_likelihood(
                             keep_conp[
                                 index_gal, n * n_inside_tau + index_tau_for] = 0
 
-            del res
-            del flux_now_i
+            #del res
+            #del flux_now_i
 
             j_s_now.extend(cont_filled.j_s_full[index_gal_eff][
                            n * n_inside_tau: (n + 1) * n_inside_tau
@@ -346,7 +346,7 @@ def _get_likelihood(
                     spectrum_now[n * n_inside_tau:(n + 1) * n_inside_tau,
                     bin_i - 1,
                     :bin_i] = spectrum_now_i.T
-                    del spectrum_now_i
+                    #del spectrum_now_i
             else:
                 continuum_i = (
                         cont_filled.la_flux_out_full[index_gal_eff][
@@ -365,7 +365,7 @@ def _get_likelihood(
                     noise_on_the_spectrum,
                     np.shape(full_flux_res_i)
                 )
-                del continuum_i
+                #del continuum_i
                 for bin_i, wav_dig_i in zip(
                         range(2, inputs.bins_tot), wave_em_dig_arr
                 ):
@@ -374,7 +374,7 @@ def _get_likelihood(
                     :bin_i] = perturb_flux(
                         full_flux_res_i, bin_i
                     )
-                del full_flux_res_i
+                #del full_flux_res_i
 
         if cache:
 
@@ -1022,7 +1022,6 @@ if __name__ == '__main__':
             ew_factor, la_e = p_EW(
                 Muv.flatten(),
                 beta.flatten(),
-                return_lum=True,
                 high_prob_emit=inputs.high_prob_emit,
                 EW_fixed=inputs.EW_fixed,
             )
@@ -1320,7 +1319,7 @@ if __name__ == '__main__':
     if inputs.mock_direc is None:
         flux_mock = la_e / (
                 4 * np.pi * Cosmo.luminosity_distance(
-            7.5).to(u.cm).value ** 2
+            redshifts_of_mocks).to(u.cm).value ** 2
         )
         flux_tau = flux_mock * tau_data_I
         flux_tau += np.random.normal(0, 5e-20, np.shape(flux_tau))

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from numpy.linalg import LinAlgError
 import argparse
 import os
 import shutil
-from scipy import integrate
 from scipy.stats import gaussian_kde
 
 from astropy.cosmology import z_at_value
@@ -264,7 +263,6 @@ def _get_likelihood(
                                          ],
                 wave_em.value
             )
-            del tau_cgm_in
             del tau_now_i
 
 

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def _get_likelihood(
         cont_filled=None,
         index_iter=None,
         constrained_prior=False,
-        reds_of_galaxies=None
+        reds_of_galaxies=None,
         dir_name=None,
 ):
     """

--- a/main.py
+++ b/main.py
@@ -464,7 +464,7 @@ def _get_likelihood(
                         tau_kde.evaluate((tau_data[ind_data]))
                     )
             if like_on_flux is not False:
-                for bin_i in range(2, bins_tot):
+                for bin_i in range(2, bins_tot-1):
 
                     if bin_i < 4:
                         data_to_get = np.log10(

--- a/main.py
+++ b/main.py
@@ -264,7 +264,7 @@ def _get_likelihood(
                                          ],
                 wave_em.value
             )
-            del tau_cgm_gal_in
+            del tau_cgm_in
             del tau_now_i
 
 
@@ -562,13 +562,11 @@ def sample_bubbles_grid(
         redshift=7.5,
         muv=None,
         beta_data=None,
-        xh_unc=False,
         la_e=None,
         flux_int=None,
         multiple_iter=False,
         flux_limit=1e-18,
         like_on_flux=False,
-        resolution_worsening=1,
         n_inside_tau=50,
         bins_tot=20,
         cache=True,
@@ -599,8 +597,6 @@ def sample_bubbles_grid(
         redshift of the analysis.
     :param muv: muv,
         UV magnitude data
-    :param include_muv_unc: boolean,
-        whether to include muv uncertainty.
     :param beta_data: float,
         beta data.
     :param xh_unc: boolean
@@ -1310,14 +1306,12 @@ if __name__ == '__main__':
         n_grid=inputs.n_grid,
         redshift=inputs.redshift,
         muv=Muv,
-        include_muv_unc=inputs.mag_unc,
         beta_data=beta,
         la_e=la_e,
         flux_int=flux_tau,
         multiple_iter=inputs.multiple_iter,
         flux_limit=inputs.flux_limit,
         like_on_flux=like_on_flux,
-        resolution_worsening=inputs.resolution_worsening,
         n_inside_tau=inputs.n_inside_tau,
         cache=inputs.cache,
         like_on_tau_full=inputs.like_on_tau_full,

--- a/main.py
+++ b/main.py
@@ -421,7 +421,7 @@ def _get_likelihood(
             tau_kde = gaussian_kde((np.array(tau_line)), bw_method=0.15)
             fl_l = np.log10(1e19 * (3e-19 + (np.array(flux_line))))
             if ind_data==0:
-                print("Just in case, this is fl_l", fl_l, flux_line, "flux_line as well", flush=True)
+                #print("Just in case, this is fl_l", fl_l, flux_line, "flux_line as well", flush=True)
             if np.any(np.isnan(fl_l.flatten())) or np.any(np.isinf(fl_l.flatten())):
                 ind_nan = np.isnan(fl_l.flatten()).index(1)
                 ind_inf = np.isinf(fl_l.flatten()).index(1)
@@ -475,9 +475,9 @@ def _get_likelihood(
                         data_to_get = np.log10(
                             1e18 * (5e-19 + spec_line[:, bin_i - 1, 1:4]).T
                         )
-                    print(data_to_get, flush=True)
-                    print("just in case, print", data_to_get[0], flush=True)
-                    print("also", data_to_get[-1], flush=True)
+                    #print(data_to_get, flush=True)
+                    #print("just in case, print", data_to_get[0], flush=True)
+                    #print("also", data_to_get[-1], flush=True)
                     # print(spec_line[:,bin_i-1, 1:bin_i], np.shape(spec_line[:,bin_i-1, 1:bin_i]))
                     spec_kde = gaussian_kde(data_to_get, bw_method=0.2)
 
@@ -500,7 +500,7 @@ def _get_likelihood(
                             data_to_eval
                         )
                     )
-            print("This is flux_int", flux_int)
+            #print("This is flux_int", flux_int)
             if flux_int[ind_data] < flux_limit:
                 print("This galaxy failed the tau test, it's flux is",
                       flux_int[ind_data])

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import datetime
 import itertools
 from joblib import Parallel, delayed
 
-from venv.galaxy_prop import get_js, get_mock_data, p_EW
+from venv.galaxy_prop import get_js, get_mock_data, p_EW, L_intr_AH22
 from venv.galaxy_prop import get_muv, tau_CGM, calculate_number
 
 from venv.save import HdF5Saver, HdF5SaverAft, HdF5SaveMocks
@@ -860,6 +860,7 @@ if __name__ == '__main__':
     parser.add_argument("--noise_on_the_spectrum", type=float, default=2e-20)
     parser.add_argument("--consistent_noise", action="store_true")
     parser.add_argument("--constrained_prior", action="store_true")
+    parser.add_argumnet("--AH22_model", action="store_true")
     inputs = parser.parse_args()
 
     if inputs.uvlf_consistently:
@@ -1009,13 +1010,17 @@ if __name__ == '__main__':
                         wave_em.value)
                 )
 
-        ew_factor, la_e = p_EW(
-            Muv.flatten(),
-            beta.flatten(),
-            return_lum=True,
-            high_prob_emit=inputs.high_prob_emit,
-            EW_fixed=inputs.EW_fixed,
-        )
+        if inputs.AH22_model:
+            la_e = L_intr_AH22(Muv.flatten())
+            ew_factor = np.ones((np.shape(Muv)))
+        else:
+            ew_factor, la_e = p_EW(
+                Muv.flatten(),
+                beta.flatten(),
+                return_lum=True,
+                high_prob_emit=inputs.high_prob_emit,
+                EW_fixed=inputs.EW_fixed,
+            )
         ew_factor = ew_factor.reshape((np.shape(Muv)))
         la_e = la_e.reshape((np.shape(Muv)))
         data = np.array(tau_data_I)
@@ -1334,6 +1339,7 @@ if __name__ == '__main__':
         high_prob_emit=inputs.high_prob_emit,
         EW_fixed=inputs.EW_fixed,
         cache=inputs.cache,
+        AH22_model=input.AH22_model,
     )
 
     likelihoods, names_used = sample_bubbles_grid(

--- a/main.py
+++ b/main.py
@@ -867,8 +867,7 @@ if __name__ == '__main__':
     parser.add_argument("--constrained_prior", action="store_true")
     parser.add_argument("--AH22_model", action="store_true")
     inputs = parser.parse_args()
-    print(inputs.constrained_prior)
-    assert False
+
     if inputs.uvlf_consistently:
         if inputs.fluct_level is None:
             raise ValueError("set you density value")

--- a/main.py
+++ b/main.py
@@ -867,7 +867,8 @@ if __name__ == '__main__':
     parser.add_argument("--constrained_prior", action="store_true")
     parser.add_argument("--AH22_model", action="store_true")
     inputs = parser.parse_args()
-
+    print(inputs.constrained_prior)
+    assert False
     if inputs.uvlf_consistently:
         if inputs.fluct_level is None:
             raise ValueError("set you density value")

--- a/main.py
+++ b/main.py
@@ -1339,7 +1339,7 @@ if __name__ == '__main__':
         high_prob_emit=inputs.high_prob_emit,
         EW_fixed=inputs.EW_fixed,
         cache=inputs.cache,
-        AH22_model=input.AH22_model,
+        AH22_model=inputs.AH22_model,
     )
 
     likelihoods, names_used = sample_bubbles_grid(

--- a/main.py
+++ b/main.py
@@ -532,7 +532,7 @@ def _get_likelihood(
         print("OOps there was value error, let's see why:", flush=True)
         # print(tau_data, flush=True)
         # print(taus_tot_b, flush=True)
-        raise TypeError
+        #raise TypeError
 
     if not cache:
         names_used_this_iter = None
@@ -848,7 +848,7 @@ if __name__ == '__main__':
     parser.add_argument("--resolution_worsening", type=float, default=1)
     parser.add_argument("--n_inside_tau", type=int, default=50)
     parser.add_argument("--n_iter_bub", type=int, default=50)
-    parser.add_argument("--bins_tot", type=int, default=15)
+    parser.add_argument("--bins_tot", type=int, default=20)
     parser.add_argument("--high_prob_emit", action="store_true")
     parser.add_argument("--cache", action="store_false")
     parser.add_argument("--fwhm_true", action="store_true")

--- a/main.py
+++ b/main.py
@@ -211,7 +211,7 @@ def _get_likelihood(
             z_end_bub = z_at_proper_distance(dist / (1 + red_s) * u.Mpc, red_s)
         else:
             z_end_bub = red_s
-            dist = 0
+
         for n in range(n_iter_bub):
             # j_s = get_js(
             #     muv=muvi,
@@ -519,8 +519,6 @@ def _get_likelihood(
                 bw_method=0.15
             )
 
-            # if la_e_in is not None:
-            #     flux_tau = flux_mock[ind_data] * tau_data[ind_data]
             # print(len(spec_kde), flush=True)
             # print(len(list(range(6,len(bins)))), flush=True)
             # like_on_flux = np.array(like_on_flux)

--- a/main.py
+++ b/main.py
@@ -420,7 +420,7 @@ def _get_likelihood(
         ):
             tau_kde = gaussian_kde((np.array(tau_line)), bw_method=0.15)
             fl_l = np.log10(1e19 * (3e-19 + (np.array(flux_line))))
-            if ind_data==0:
+            #if ind_data==0:
                 #print("Just in case, this is fl_l", fl_l, flux_line, "flux_line as well", flush=True)
             if np.any(np.isnan(fl_l.flatten())) or np.any(np.isinf(fl_l.flatten())):
                 ind_nan = np.isnan(fl_l.flatten()).index(1)

--- a/venv/__init__.py
+++ b/venv/__init__.py
@@ -1,4 +1,4 @@
-from venv.galaxy_prop import get_js, get_mock_data
+from venv.galaxy_prop import get_js, get_mock_data, L_intr_AH22
 from venv.igm_prop import get_bubbles, calculate_taus, calculate_taus_i, tau_wv
 from venv.helpers import optical_depth, comoving_distance_from_source_Mpc
 from venv.save import HdF5Saver, HdF5SaveMocks

--- a/venv/galaxy_prop.py
+++ b/venv/galaxy_prop.py
@@ -1,6 +1,6 @@
 import numpy as np
 from astropy import units as u
-from numpy.random import normal
+from numpy.random import normal, binomial
 from astropy.cosmology import z_at_value
 from astropy.cosmology import Planck18 as Cosmo
 from scipy import integrate
@@ -615,3 +615,44 @@ def get_spectrum(
 
     return 0.5 * (bins_po[1:] + bins_po[:-1]), cont_flux
 
+
+def L_intr_AH22(Muv):
+    def sigma(mh):
+        if mh > 1e10:
+            return 0.1  # log-normal
+        else:
+            return 1.0
+
+    csv_AH_22 = np.loadtxt(
+        '/home/inikolic/projects/Lyalpha_bubbles/Literature/AH+22/L_intr_Mass.csv',
+        delimiter=','
+    )
+    mass = csv_AH_22[:, 0]
+    L_intr = csv_AH_22[:, 1]
+    Muvs = np.load(
+        '/home/inikolic/projects/Lyalpha_bubbles/code/Lyman-alpha-bubbles/venv/data/Muv.npy')
+    mh = np.load(
+        '/home/inikolic/projects/Lyalpha_bubbles/code/Lyman-alpha-bubbles/venv/data/mh.npy')
+    mh_now = np.interp(Muv, np.flip(Muvs), np.flip(mh))
+    mean_L = np.interp(np.log10(mh_now), np.log10(mass), L_intr)
+
+    print(np.log10(mh_now))
+    if hasattr(mh_now, '__len__'):
+        li = np.zeros(np.shape(Muv))
+        for ind, (mi, meanil) in enumerate(
+                zip(mh_now.flatten(), mean_L.flatten())):
+            if mi > 1e10:
+                li[ind] = 10 ** normal(meanil, 0.4)
+            else:
+                if binomial(0.5):
+                    li[ind] = 10 ** normal(meanil, 1.0)
+                else:
+                    li[ind] = 0.0
+        return li.reshape(np.shape(Muv))
+    if mh_now > 1e10:
+        return 10 ** normal(mean_L, 0.4)
+    else:
+        if binomial(0.5):
+            return 10 ** normal(mean_L, 1.0)
+        else:
+            return 0.0

--- a/venv/galaxy_prop.py
+++ b/venv/galaxy_prop.py
@@ -232,6 +232,8 @@ def get_mock_data(
         else:
             dist = 0
             z_end_bub = red_s
+
+        #Is it maybe different inconsistent taus?
         tau = calculate_taus_i(
             x_b,
             y_b,

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -198,6 +198,7 @@ def get_content(
         )(m,b,r) for (m,b,r) in zip(Muvs, beta, redshifts_of_mocks)
     )
     print(res)
+    assert False
 
     outputs = Parallel(
         n_jobs=30

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -188,6 +188,17 @@ def get_content(
             fi_bu_en_czl_i
         )
 
+    #checking out how delayed and Parallel work
+    print(Muvs, beta, redshift_of_mocks)
+    def _fake_func(m,b,r):
+        return m,b,r
+    res = Parallel(n_jobs=30)(
+        delayed(
+            _fake_func
+        )(m,b,r) for (m,b,r) in zip(Muvs, beta, redshifts_of_mocks)
+    )
+    print(res)
+
     outputs = Parallel(
         n_jobs=30
     )(delayed(

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -163,7 +163,7 @@ def get_content(
             y_out_gal_i.append(y_outs)
             z_out_gal_i.append(z_outs)
             r_out_gal_i.append(r_bubs)
-            if AH22_model:
+            if not AH22_model:
                 lae_now_i = np.array(
                     [p_EW(
                         muv_i,

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -189,7 +189,7 @@ def get_content(
         )
 
     #checking out how delayed and Parallel work
-    print(Muvs, beta, redshift_of_mocks)
+    print(Muvs, beta, redshifts_of_mocks)
     def _fake_func(m,b,r):
         return m,b,r
     res = Parallel(n_jobs=30)(

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -397,19 +397,29 @@ def calculate_taus_prep(
         red_edge_up_sorted = red_edge_up[np.flip(indices_up)]
         red_edge_lo_sorted = red_edge_lo[np.flip(indices_up)]
 
-        indices_to_del_lo = []
-        indices_to_del_up = []
-        for i_fi in range(len(z_edge_up) - 1):
-            if len(z_edge_up_sorted) != 1:
-                if z_edge_lo_sorted[i_fi] < z_edge_up_sorted[i_fi + 1]:
-                    # got an overlapping bubble
-                    indices_to_del_lo.append(i_fi)
-                    indices_to_del_up.append(i_fi + 1)
-        z_edge_lo_sorted = np.delete(z_edge_lo_sorted, indices_to_del_lo)
-        z_edge_up_sorted = np.delete(z_edge_up_sorted, indices_to_del_up)
-        red_edge_up_sorted = np.delete(red_edge_up_sorted, indices_to_del_up)
-        red_edge_lo_sorted = np.delete(red_edge_lo_sorted, indices_to_del_lo)
+        while True:
+            indices_to_del_lo = []
+            indices_to_del_up = []
+            for i_fi in range(len(z_edge_up_sorted) - 1):
+                if len(z_edge_up_sorted) != 1:
+                    if z_edge_lo_sorted[i_fi] < z_edge_up_sorted[i_fi + 1]:
+                        # got an overlapping bubble
+                        indices_to_del_lo.append(i_fi)
+                        indices_to_del_up.append(i_fi + 1)
+            if len(indices_to_del_lo) == 0:
+                break
+            z_edge_lo_sorted = np.delete(z_edge_lo_sorted, indices_to_del_lo)
+            z_edge_up_sorted = np.delete(z_edge_up_sorted, indices_to_del_up)
+            red_edge_up_sorted = np.delete(red_edge_up_sorted,
+                                           indices_to_del_up)
+            red_edge_lo_sorted = np.delete(red_edge_lo_sorted,
+                                           indices_to_del_lo)
         tau_i = np.zeros(len(wave_em))
+
+        red_edge_up_sorted = np.flip(red_edge_up_sorted)
+        z_edge_up_sorted = np.flip(z_edge_up_sorted)
+        red_edge_lo_sorted = np.flip(red_edge_lo_sorted)
+        z_edge_lo_sorted = np.flip(z_edge_lo_sorted)
 
         # up to this point, redshifts are calculated for ionized bubbles.
         # An idea is to calculate taus for all outside bubbles, and remember the
@@ -470,7 +480,6 @@ def calculate_taus_prep(
             else:
                 raise IndexError("Something else")
     taus = taus.flatten()
-    taus[taus < 0.0] = np.inf
 
     return (
         taus.reshape((n_iter, len(wave_em))),
@@ -505,7 +514,7 @@ def calculate_taus_post(
         tau_i = np.zeros((len(wave_em)))
         if z_up_i == np.inf:
 
-            dist = comoving_distance_from_source_Mpc(z_source, z_end_bubble)
+            dist = comoving_distance_from_source_Mpc(z_source, z_end_bubble).value
             taus[index_iter, :] = tau_wv(
                 wave_em,
                 dist=dist,
@@ -549,5 +558,4 @@ def calculate_taus_post(
             else:
                 raise IndexError("Something else")
     taus = taus.flatten()
-    taus[taus < 0.0] = np.inf
     return taus.reshape((n_iter, len(wave_em)))

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -116,11 +116,11 @@ def get_content(
 
     cont_now = OutsideContainer()
 
-    com_factor = np.zeros(len(Muvs))
-    for index_gal in range(len(Muvs)):
+    com_factor = np.zeros(len(Muvs.flatten()))
+    for index_gal in range(len(Muvs.flatten())):
         com_factor[index_gal] = 1 / (4 * np.pi * Cosmo.luminosity_distance(
-            redshifts_of_mocks[index_gal]).to(u.cm).value ** 2)
-    cont_now.add_com_fact(com_factor)
+            redshifts_of_mocks.flatten()[index_gal]).to(u.cm).value ** 2)
+    cont_now.add_com_fact(com_factor.reshape(np.shape(Muvs)))
 
     if beta is None:
         beta = np.array([-2.0] * len(Muvs))

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -188,18 +188,6 @@ def get_content(
             fi_bu_en_czl_i
         )
 
-    #checking out how delayed and Parallel work
-    print(Muvs, beta, redshifts_of_mocks)
-    def _fake_func(m,b,r):
-        return m,b,r
-    res = Parallel(n_jobs=30)(
-        delayed(
-            _fake_func
-        )(m,b,r) for (m,b,r) in zip(Muvs, beta, redshifts_of_mocks)
-    )
-    print(res)
-    assert False
-
     outputs = Parallel(
         n_jobs=30
     )(delayed(

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -514,7 +514,7 @@ def calculate_taus_post(
         tau_i = np.zeros((len(wave_em)))
         if z_up_i == np.inf:
 
-            dist = comoving_distance_from_source_Mpc(z_source, z_end_bubble).value
+            dist = comoving_distance_from_source_Mpc(z_source, z_end_bubble)
             taus[index_iter, :] = tau_wv(
                 wave_em,
                 dist=dist,

--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -1,5 +1,5 @@
 import numpy as np
-from venv.galaxy_prop import get_js, p_EW
+from venv.galaxy_prop import get_js, p_EW, L_intr_AH22
 from venv.igm_prop import get_xH, get_bubbles
 from astropy import units as u
 from astropy import constants as const
@@ -89,6 +89,7 @@ def get_content(
         high_prob_emit=False,
         EW_fixed=False,
         cache=True,
+        AH22_model=False,
         cache_dir='/home/inikolic/projects/Lyalpha_bubbles/_cache/',
 ):
     """
@@ -162,14 +163,19 @@ def get_content(
             y_out_gal_i.append(y_outs)
             z_out_gal_i.append(z_outs)
             r_out_gal_i.append(r_bubs)
-            lae_now_i = np.array(
-                [p_EW(
-                    muv_i,
-                    beti,
-                    high_prob_emit=high_prob_emit,
-                    EW_fixed=EW_fixed,
-                )[1] for blah in range(n_inside_tau)]
-            )
+            if AH22_model:
+                lae_now_i = np.array(
+                    [p_EW(
+                        muv_i,
+                        beti,
+                        high_prob_emit=high_prob_emit,
+                        EW_fixed=EW_fixed,
+                    )[1] for blah in range(n_inside_tau)]
+                )
+            else:
+                lae_now_i = np.array(
+                    [L_intr_AH22(muv_i) for blah in range(n_inside_tau)]
+                )
 
             la_flux_gal_i[
             bubble_iter * n_inside_tau: (bubble_iter + 1) * n_inside_tau


### PR DESCRIPTION
There is a bug that leads to incorrect inference when using the new code which pre-computes forward-models. First attempt is to check whether there is a shift in the order of galaxies because of poor parallelization.