### PR TITLE
Fixing the issue with optical depths

### DIFF
--- a/venv/speed_up.py
+++ b/venv/speed_up.py
@@ -554,12 +554,12 @@ def calculate_taus_post(
                 tau_i = tau_pref * zb_ar ** 1.5 * (
                         I(zb_ar) - I((1 + z_ei) * one_over_onepz)
                 )
-        try:
-            taus[index_iter, :] = tau_i
-        except IndexError:
-            if n_iter == 1:
-                taus = tau_i
-            else:
-                raise IndexError("Something else")
+            try:
+                taus[index_iter, :] = tau_i
+            except IndexError:
+                if n_iter == 1:
+                    taus = tau_i
+                else:
+                    raise IndexError("Something else")
     taus = taus.flatten()
     return taus.reshape((n_iter, len(wave_em)))


### PR DESCRIPTION
Commit summary:
- in case there are only negative values in the whole row of optical depth, just use the mean version (tau_wv). This is an approximation, and a more correct treatement will require a larger fix.
- There was a bug that assigned zeros if there was no outside bubble intersections.