### PR TITLE
Constrained prior run should be done consistently

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def _get_likelihood(
     # calculation. The only thing to define is the width of the distribution
     # and the rejection criterion
     if constrained_prior:
-        width_conp = 0.2
+        width_conp = 0.05
 
     likelihood_spec = np.zeros((len(xs), bins_tot - 1))
     likelihood_int = np.zeros((len(xs)))

--- a/main.py
+++ b/main.py
@@ -606,7 +606,7 @@ def _get_likelihood(
         print("OOps there was value error, let's see why:", flush=True)
         # print(tau_data, flush=True)
         # print(taus_tot_b, flush=True)
-        #raise TypeError
+        raise ValueError
 
     if not cache:
         names_used_this_iter = None

--- a/main.py
+++ b/main.py
@@ -116,7 +116,6 @@ def _get_likelihood(
         reds_of_galaxies_in = np.zeros(len(xs))
     else:
         reds_of_galaxies_in = reds_of_galaxies
-    print(len(xs), "this is the number of galaxies senor", flush=True)
 
     names_used_this_iter = []
 
@@ -429,9 +428,7 @@ def _get_likelihood(
                     taus_tot_cp.append(np.array(li)[(keep_conp[ind_i_gal]).astype(np.bool)])
                     flux_tot_cp.append(np.array(fi)[(keep_conp[ind_i_gal]).astype(np.bool)])
                     spec_tot_cp.append(np.array(speci)[(keep_conp[ind_i_gal]).astype(np.bool)])
-                    print(np.array(li), keep_conp[ind_i_gal])
-                    print("Let's see what's actually done in constrained prior")
-                    print(taus_tot_b, len(taus_tot_b))
+
                 taus_tot_b.append(li)
                 flux_tot_b.append(fi)
                 spectrum_tot_b.append(speci)

--- a/main.py
+++ b/main.py
@@ -428,7 +428,7 @@ def _get_likelihood(
                     taus_tot_cp.append(np.array(li)[(keep_conp[ind_i_gal]).astype(np.bool)])
                     flux_tot_cp.append(np.array(fi)[(keep_conp[ind_i_gal]).astype(np.bool)])
                     spec_tot_cp.append(np.array(speci)[(keep_conp[ind_i_gal]).astype(np.bool)])
-
+                    print(keep_conp[ind_i_gal])
                 taus_tot_b.append(li)
                 flux_tot_b.append(fi)
                 spectrum_tot_b.append(speci)
@@ -505,7 +505,6 @@ def _get_likelihood(
                     #print("also", data_to_get[-1], flush=True)
                     # print(spec_line[:,bin_i-1, 1:bin_i], np.shape(spec_line[:,bin_i-1, 1:bin_i]))
                     spec_kde = gaussian_kde(data_to_get, bw_method=0.2)
-
                     if bin_i < 4:
                         data_to_eval = np.log10(
                             (1e18 * (
@@ -527,6 +526,9 @@ def _get_likelihood(
                     )
                 if constrained_prior:
                     for bin_i in range(2, bins_tot):
+                        print(len(spec_line), len(spec_tot_cp[ind_data]), flush=True)
+                        print("Lengths")
+
                         if bin_i < 4:
                             data_to_get = np.log10(
                                 1e18 * (5e-19 + spec_tot_cp[ind_data][:, bin_i - 1,

--- a/main.py
+++ b/main.py
@@ -307,14 +307,16 @@ def _get_likelihood(
                 raise ValueError
 
             if constrained_prior:
-                #if flux_int[index_gal] > flux_limit:
-                for index_tau_for, res_i_for in enumerate(res):
-                    if abs(res_i_for - tau_data[index_gal]) < width_conp:
-                        keep_conp[
-                            index_gal, n * n_inside_tau + index_tau_for] = 1
-                    else:
-                        keep_conp[
-                            index_gal, n * n_inside_tau + index_tau_for] = 0
+                if flux_int[index_gal] > flux_limit:
+                    for index_tau_for, lae_i_for in enumerate(lae_now[
+                        n * n_inside_tau:(n + 1) * n_inside_tau
+                    ]):
+                        if abs((lae_i_for - la_e_in[index_gal])/la_e_in[index_gal]) < width_conp:
+                            keep_conp[
+                                index_gal, n * n_inside_tau + index_tau_for] = 1
+                        else:
+                            keep_conp[
+                                index_gal, n * n_inside_tau + index_tau_for] = 0
 
             #del res
             #del flux_now_i

--- a/main.py
+++ b/main.py
@@ -307,7 +307,7 @@ def _get_likelihood(
                 raise ValueError
 
             if constrained_prior:
-                if flux_int[index_gal] > flux_limit:
+                if flux_int[index_gal] > 2 * flux_limit:
                     for index_tau_for, lae_i_for in enumerate(lae_now[
                         n * n_inside_tau:(n + 1) * n_inside_tau
                     ]):

--- a/main.py
+++ b/main.py
@@ -435,7 +435,8 @@ def _get_likelihood(
                 flux_tot_b.append(fi)
                 spectrum_tot_b.append(speci)
         #        print(np.shape(taus_tot_b), np.shape(tau_data), flush=True)
-
+        print(flux_tot_cp, "This is flux_tot_cp", flush=True)
+        print(flux_tot_b, "This is flux_tot_b", flush=True)
         for ind_data, (flux_line, tau_line, spec_line) in enumerate(
                 zip(np.array(flux_tot_b), np.array(taus_tot_b),
                     np.array(spectrum_tot_b))

--- a/main.py
+++ b/main.py
@@ -435,8 +435,8 @@ def _get_likelihood(
                 flux_tot_b.append(fi)
                 spectrum_tot_b.append(speci)
         #        print(np.shape(taus_tot_b), np.shape(tau_data), flush=True)
-        print(flux_tot_cp, "This is flux_tot_cp", flush=True)
-        print(flux_tot_b, "This is flux_tot_b", flush=True)
+        # print(flux_tot_cp, "This is flux_tot_cp", flush=True)
+        # print(flux_tot_b, "This is flux_tot_b", flush=True)
         for ind_data, (flux_line, tau_line, spec_line) in enumerate(
                 zip(np.array(flux_tot_b), np.array(taus_tot_b),
                     np.array(spectrum_tot_b))
@@ -445,6 +445,9 @@ def _get_likelihood(
             fl_l = np.log10(1e19 * (3e-19 + (np.array(flux_line))))
             if constrained_prior:
                 fl_l_cp = np.log10(1e19 * (3e-19 + (np.array(flux_tot_cp[ind_data]))))
+            if len(fl_l_cp) == 0:
+                print("This is the problem", ind_data, flush=True)
+                print(la_e_in[ind_data], flux_int[ind_data], reds_of_galaxies_in[ind_data], flush=True)
             #if ind_data==0:
                 #print("Just in case, this is fl_l", fl_l, flux_line, "flux_line as well", flush=True)
             if np.any(np.isnan(fl_l.flatten())) or np.any(np.isinf(fl_l.flatten())):

--- a/main.py
+++ b/main.py
@@ -1391,7 +1391,8 @@ if __name__ == '__main__':
         redshifts_of_mocks=redshifts_of_mocks,
         bins_tot=inputs.bins_tot,
         main_dir=inputs.main_dir,
-        cache_dir=inputs.cache_dir
+        cache_dir=inputs.cache_dir,
+        constrained_prior=inputs.constrained_prior
     )
 
     dict_to_save_data = dict()

--- a/main.py
+++ b/main.py
@@ -611,9 +611,9 @@ def _get_likelihood(
         likelihood_int[:ind_data] += -np.inf
 
         print("OOps there was value error, let's see why:", flush=True)
-        # print(tau_data, flush=True)
+        print(spec_tot_cp[ind_data], flush=True)
         # print(taus_tot_b, flush=True)
-        raise ValueError
+        #raise ValueError
 
     if not cache:
         names_used_this_iter = None

--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ def _get_likelihood(
 
     names_used_this_iter = []
 
-    keep_conp = np.ones((len(xs), n_inside_tau * n_iter_bub))
+    keep_conp = np.ones((len(xs), n_inside_tau * n_iter_bub), dtype=int)
 
     for index_gal, (xg, yg, zg, muvi, beti, li) in enumerate(
             zip(xs, ys, zs, muv, beta_data, la_e_in)

--- a/main.py
+++ b/main.py
@@ -419,9 +419,9 @@ def _get_likelihood(
                 zip(flux_tot, taus_tot, spectrum_tot)):
             if np.all(np.array(li) < 10000.0):  # maybe unnecessary
                 if constrained_prior:
-                    taus_tot_b.append(np.array(li)[keep_conp[ind_i_gal]])
-                    flux_tot_b.append(np.array(fi)[keep_conp[ind_i_gal]])
-                    spectrum_tot_b.append(np.array(speci)[keep_conp[ind_i_gal]])
+                    taus_tot_b.append(np.array(li)[(keep_conp[ind_i_gal]).astype(np.bool)])
+                    flux_tot_b.append(np.array(fi)[(keep_conp[ind_i_gal]).astype(np.bool)])
+                    spectrum_tot_b.append(np.array(speci)[(keep_conp[ind_i_gal]).astype(np.bool)])
                     print(np.array(li), keep_conp[ind_i_gal])
                     print("Let's see what's actually done in constrained prior")
                     print(taus_tot_b, len(taus_tot_b))

--- a/main.py
+++ b/main.py
@@ -538,7 +538,7 @@ def _get_likelihood(
                         print(len(spec_line), len(spec_tot_cp[ind_data]), flush=True)
                         print("Lengths")
 
-                        if bin_i < 4:
+                        if bin_i < 6:
                             data_to_get = np.log10(
                                 1e18 * (5e-19 + spec_tot_cp[ind_data][:, bin_i - 1,
                                                 1:bin_i]).T

--- a/main.py
+++ b/main.py
@@ -422,6 +422,9 @@ def _get_likelihood(
                     taus_tot_b.append(np.array(li)[keep_conp[ind_i_gal]])
                     flux_tot_b.append(np.array(fi)[keep_conp[ind_i_gal]])
                     spectrum_tot_b.append(np.array(speci)[keep_conp[ind_i_gal]])
+
+                    print("Let's see what's actually done in constrained prior")
+                    print(taus_tot_b, len(taus_tot_b))
                 else:
                     taus_tot_b.append(li)
                     flux_tot_b.append(fi)

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def _get_likelihood(
     # calculation. The only thing to define is the width of the distribution
     # and the rejection criterion
     if constrained_prior:
-        width_conp = 0.05
+        width_conp = 0.2
 
     likelihood_spec = np.zeros((len(xs), bins_tot - 1))
     likelihood_int = np.zeros((len(xs)))

--- a/main.py
+++ b/main.py
@@ -307,14 +307,14 @@ def _get_likelihood(
                 raise ValueError
 
             if constrained_prior:
-                if flux_int[index_gal] > flux_limit:
-                    for index_tau_for, res_i_for in enumerate(res):
-                        if abs(res_i_for - tau_data[index_gal]) < width_conp:
-                            keep_conp[
-                                index_gal, n * n_inside_tau + index_tau_for] = 1
-                        else:
-                            keep_conp[
-                                index_gal, n * n_inside_tau + index_tau_for] = 0
+                #if flux_int[index_gal] > flux_limit:
+                for index_tau_for, res_i_for in enumerate(res):
+                    if abs(res_i_for - tau_data[index_gal]) < width_conp:
+                        keep_conp[
+                            index_gal, n * n_inside_tau + index_tau_for] = 1
+                    else:
+                        keep_conp[
+                            index_gal, n * n_inside_tau + index_tau_for] = 0
 
             #del res
             #del flux_now_i

--- a/main.py
+++ b/main.py
@@ -422,7 +422,7 @@ def _get_likelihood(
                     taus_tot_b.append(np.array(li)[keep_conp[ind_i_gal]])
                     flux_tot_b.append(np.array(fi)[keep_conp[ind_i_gal]])
                     spectrum_tot_b.append(np.array(speci)[keep_conp[ind_i_gal]])
-
+                    print(np.array(li), keep_conp[ind_i_gal])
                     print("Let's see what's actually done in constrained prior")
                     print(taus_tot_b, len(taus_tot_b))
                 else:

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def _get_likelihood(
     # calculation. The only thing to define is the width of the distribution
     # and the rejection criterion
     if constrained_prior:
-        width_conp = 0.2
+        width_conp = 0.3
 
     likelihood_spec = np.zeros((len(xs), bins_tot - 1))
     likelihood_int = np.zeros((len(xs)))


### PR DESCRIPTION
Since I want to compare results with like-to-like things, I should do constrained_prior run at the same time as the other configurations (if the flag is called, of course). This shouldn't take too much of coding.

First thing though, constrained prior hasn't been even called so far so that needs to be changed.